### PR TITLE
Adding configuration options to manage timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,31 +11,31 @@ One group only supports one resolution, and different resolutions need to be in 
 However a single group can support both H264 and JPEG capture formats.
 
 
-Config options in settings.json
+**Config options in settings.json**
 
-flip_vertical:
+_flip_vertical:_
 - 0 no flip
 - 1 vertical flip
 
-flip_horizontal:
+_flip_horizontal:_
 - 0 no flip
 - 1 horizontal flip
 
-timestamp_24h:
+_timestamp_24h:_
 - 0 12h display
 - 1 24h display
 
-timestamp_location:
+_timestamp_location:_
 - 0 top left corner
 - 1 top roght corner
 - 2 bottom left corner
 - 3 bottom right corner
 
-show_timestamp:
+_show_timestamp:_
 - 0 disable timestampt
 - 1 enable timestamp
 
-enable_audio:
+_enable_audio:_
 - 0 disable audio
 - 1 enable audio
 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,33 @@ The secondary stream must be channel 1, group 1.
 
 One group only supports one resolution, and different resolutions need to be in distinct groups.
 However a single group can support both H264 and JPEG capture formats.
+
+
+Config options in settings.json
+
+flip_vertical:
+- 0 no flip
+- 1 vertical flip
+
+flip_horizontal:
+- 0 no flip
+- 1 horizontal flip
+
+timestamp_24h:
+- 0 12h display
+- 1 24h display
+
+timestamp_location:
+- 0 top left corner
+- 1 top roght corner
+- 2 bottom left corner
+- 3 bottom right corner
+
+show_timestamp:
+- 0 disable timestampt
+- 1 enable timestamp
+
+enable_audio:
+- 0 disable audio
+- 1 enable audio
+

--- a/settings.json
+++ b/settings.json
@@ -3,6 +3,8 @@
   "general_settings": {
     "flip_vertical": 0,
     "flip_horizontal": 0,
+    "timestamp_24h": 0,
+    "timestamp_location": 1,
     "show_timestamp": 1,
     "enable_audio": 0
   },

--- a/src/capture.c
+++ b/src/capture.c
@@ -635,10 +635,10 @@ void *timestamp_osd_entry_start(void *timestamp_osd_thread_params)
   }
 
   if (camera_config->timestamp_24h <= 0) {
-    const char DateFormat = "%Y-%m-%d %H:%M:%S";
+    const char DateFormat = "%Y-%m-%d %I:%M:%S %p";
   }
   else {
-    const char DateFormat = "%Y-%m-%d %I:%M:%S %p";
+    const char DateFormat = "%Y-%m-%d %H:%M:%S";
   }
 
   ret = IMP_OSD_ShowRgn(osdRegion, groupNumber, 1);

--- a/src/capture.c
+++ b/src/capture.c
@@ -549,19 +549,19 @@ int initialize_osd(int osdLoc)
   memset(&rAttrFont, 0, sizeof(IMPOSDRgnAttr));
   rAttrFont.type = OSD_REG_PIC;
   switch(osdLoc) {
-    case '1': //top right
+    case 1: //top right
       rAttrFont.rect.p1.x = SENSOR_WIDTH - 10;
       rAttrFont.rect.p0.x = rAttrFont.rect.p1.x - 20 * OSD_REGION_WIDTH + 1;
       rAttrFont.rect.p0.y = 10;
       rAttrFont.rect.p1.y = rAttrFont.rect.p0.y + OSD_REGION_HEIGHT - 1;
       break;
-    case '2': //bottom left
+    case 2: //bottom left
       rAttrFont.rect.p0.x = 10;
       rAttrFont.rect.p1.x = rAttrFont.rect.p0.x + 20 * OSD_REGION_WIDTH - 1;
       rAttrFont.rect.p1.y = SENSOR_HEIGHT - 10;
       rAttrFont.rect.p0.y = rAttrFont.rect.p1.y - OSD_REGION_HEIGHT + 1;
       break;
-    case '3': //bottom right
+    case 3: //bottom right
       rAttrFont.rect.p1.x = SENSOR_WIDTH - 10;
       rAttrFont.rect.p0.x = rAttrFont.rect.p1.x - 20 * OSD_REGION_WIDTH + 1;
       rAttrFont.rect.p1.y = SENSOR_HEIGHT - 10;

--- a/src/capture.c
+++ b/src/capture.c
@@ -616,10 +616,7 @@ void *timestamp_osd_entry_start(void *timestamp_osd_thread_params)
   CameraConfig *camera_config = (CameraConfig *)timestamp_osd_thread_params;
 
   /*generate time*/
-  char DateStr[40];
-  char DateFormat[40];
-  time_t currTime;
-  struct tm *currDate;
+&
   unsigned i = 0, j = 0;
   void *dateData = NULL;
   uint32_t *timeStampData;
@@ -634,12 +631,10 @@ void *timestamp_osd_entry_start(void *timestamp_osd_thread_params)
     log_info("On screen timestamps not configured.");
     return NULL;
   }
-
+  
+  char* DateFormat = "%Y-%m-%d %H:%M:%S";
   if (camera_config->timestamp_24h <= 0) {
     DateFormat = "%Y-%m-%d %I:%M:%S %p";
-  }
-  else {
-    DateFormat = "%Y-%m-%d %H:%M:%S";
   }
 
   ret = IMP_OSD_ShowRgn(osdRegion, groupNumber, 1);

--- a/src/capture.c
+++ b/src/capture.c
@@ -616,7 +616,9 @@ void *timestamp_osd_entry_start(void *timestamp_osd_thread_params)
   CameraConfig *camera_config = (CameraConfig *)timestamp_osd_thread_params;
 
   /*generate time*/
-&
+  char DateStr[40];
+  time_t currTime;
+  struct tm *currDate;
   unsigned i = 0, j = 0;
   void *dateData = NULL;
   uint32_t *timeStampData;

--- a/src/capture.c
+++ b/src/capture.c
@@ -628,7 +628,7 @@ void *timestamp_osd_entry_start(void *timestamp_osd_thread_params)
       time(&currTime);
       currDate = localtime(&currTime);
       memset(DateStr, 0, 40);
-      strftime(DateStr, 40, "%Y-%m-%d %I:%M:%S", currDate);
+      strftime(DateStr, 40, "%Y-%m-%d %H:%M:%S", currDate);
       for (i = 0; i < 20; i++) {
         switch(DateStr[i]) {
           case '0' ... '9':

--- a/src/capture.c
+++ b/src/capture.c
@@ -617,6 +617,7 @@ void *timestamp_osd_entry_start(void *timestamp_osd_thread_params)
 
   /*generate time*/
   char DateStr[40];
+  char DateFormat[40];
   time_t currTime;
   struct tm *currDate;
   unsigned i = 0, j = 0;
@@ -635,10 +636,10 @@ void *timestamp_osd_entry_start(void *timestamp_osd_thread_params)
   }
 
   if (camera_config->timestamp_24h <= 0) {
-    const char DateFormat = "%Y-%m-%d %I:%M:%S %p";
+    DateFormat = "%Y-%m-%d %I:%M:%S %p";
   }
   else {
-    const char DateFormat = "%Y-%m-%d %H:%M:%S";
+    DateFormat = "%Y-%m-%d %H:%M:%S";
   }
 
   ret = IMP_OSD_ShowRgn(osdRegion, groupNumber, 1);
@@ -658,7 +659,7 @@ void *timestamp_osd_entry_start(void *timestamp_osd_thread_params)
       currDate = localtime(&currTime);
       memset(DateStr, 0, 40);
       // strftime(DateStr, 40, "%Y-%m-%d %H:%M:%S", currDate);
-      strftime(DateStr, 40, *DateFormat, currDate);
+      strftime(DateStr, 40, DateFormat, currDate);
       for (i = 0; i < 20; i++) {
         switch(DateStr[i]) {
           case '0' ... '9':

--- a/src/configparser.c
+++ b/src/configparser.c
@@ -255,10 +255,14 @@ void print_general_settings(CameraConfig *camera_config)
                    "flip_vertical: %d\n"
                    "flip_horizontal: %d\n"
                    "show_timestamp: %d\n"
+                   "timestamp_24h: %d\n"
+                   "timestamp_location: %d\n"
                    "enable_audio: %d\n",
                     camera_config->flip_vertical,
                     camera_config->flip_horizontal,
                     camera_config->show_timestamp,
+                    camera_config->timestamp_24h,
+                    camera_config->timestamp_location,
                     camera_config->enable_audio
                     );
   log_info("%s", buffer);

--- a/src/include/streamsettings.h
+++ b/src/include/streamsettings.h
@@ -112,6 +112,8 @@ typedef struct {
 	uint32_t flip_vertical;
 	uint32_t flip_horizontal;
 	uint32_t show_timestamp;
+	uint32_t timestamp_24h;
+	uint32_t timestamp_location;
 	uint32_t enable_audio;
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -258,11 +258,23 @@ int load_general_settings(cJSON *json, CameraConfig *camera_config)
   cJSON *flip_vertical = cJSON_GetObjectItemCaseSensitive(json_general_settings, "flip_vertical");
   cJSON *flip_horizontal = cJSON_GetObjectItemCaseSensitive(json_general_settings, "flip_horizontal");
   cJSON *show_timestamp = cJSON_GetObjectItemCaseSensitive(json_general_settings, "show_timestamp");
+  cJSON *timestamp_24h = cJSON_GetObjectItemCaseSensitive(json_general_settings, "timestamp_24h");
+  cJSON *timestamp_location = cJSON_GetObjectItemCaseSensitive(json_general_settings, "timestamp_location");
   cJSON *enable_audio = cJSON_GetObjectItemCaseSensitive(json_general_settings, "enable_audio");
 
   camera_config->flip_vertical = flip_vertical->valueint;
   camera_config->flip_horizontal = flip_horizontal->valueint;
   camera_config->show_timestamp = show_timestamp->valueint;
+
+  camera_config->timestamp_24h = 0;
+  if (timestamp_24h) {
+    camera_config->timestamp_24h = timestamp_24h->valueint;
+  }
+
+  camera_config->timestamp_location = 0;
+  if (timestamp_location) {
+    camera_config->timestamp_location = timestamp_location->valueint;
+  }
 
   camera_config->enable_audio = 0;
   if (enable_audio) {


### PR DESCRIPTION
Hi,

added new settings to manage the timestamp location and format:
- timestamp_24h: if set the timestamp will use 24h format
- timstamp_location: 0..3 will define different corners for the OSD timestamp
Tested and works fine on my camera.

Thanks
